### PR TITLE
Negotiate authentication support with cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ build
 target
 lib
 *.dot
+*.iml
+.idea/
 
 # use glob syntax.
 syntax: glob

--- a/project.clj
+++ b/project.clj
@@ -2,17 +2,16 @@
   :description "Http client for ClojureCLR based on clj-http-lite."
   :url "https://github.com/whamtet/clr-http-lite/"
   :dependencies [
-                 [org.clojure/clojure "1.6.0"]
-            [ring/ring-jetty-adapter "1.3.2"]
-            [ring/ring-devel "1.3.2"]]
-  :plugins [[lein-clr "0.2.0"]
+                  [org.clojure/clojure "1.6.0"]
+                  [ring/ring-jetty-adapter "1.3.2"]
+                  [ring/ring-devel "1.3.2"]
+                 ]
+  :plugins [
+            [lein-clr "0.2.0"]
             ]
   :clr {
-;        :main-cmd      [:clj-exe "Clojure.Main.exe"]
-        :compile-cmd   [:clj-exe "Clojure.Compile.exe"]
-        :cmd-templates{
-                       :clj-exe   [
-                                   ["Z:\\Downloads\\clojure-clr\\bin\\4.0\\Release" %1] ;latest build
-                                   ]
-                       }}
+        :cmd-templates  {:clj-exe   [[CLJCLR14_40 %1]]}
+        :main-cmd [:clj-exe "Clojure.Main.exe"]
+        :compile-cmd [:clj-exe "Clojure.Compile.exe"]
+        }
   )

--- a/src/clr_http/lite/client.clj
+++ b/src/clr_http/lite/client.clj
@@ -15,7 +15,7 @@
         (for [encoding (Encoding/GetEncodings)]
           [(.Name encoding) (.GetEncoding encoding)])))
 
-(defn update [m k f & args]
+(defn update-http [m k f & args]
   (assoc m k (apply f (m k) args)))
 
 (defn parse-url [url]
@@ -63,12 +63,12 @@
   (fn [req]
     (if (get-in req [:headers "Accept-Encoding"])
       (client req)
-      (let [req-c (update req :headers assoc "Accept-Encoding" "gzip, deflate")
+      (let [req-c (update-http req :headers assoc "Accept-Encoding" "gzip, deflate")
             resp-c (client req-c)]
         (case (or (get-in resp-c [:headers "Content-Encoding"])
                   (get-in resp-c [:headers "content-encoding"]))
-          "gzip" (update resp-c :body util/gunzip)
-          "deflate" (update resp-c :body util/inflate)
+          "gzip" (update-http resp-c :body util/gunzip)
+          "deflate" (update-http resp-c :body util/inflate)
           resp-c)))))
 
 (defn wrap-output-coercion [client]


### PR DESCRIPTION
Hello,
I added the functionnality allowing a user to authenticate to a website with the Negotiate authentication (it is generally done by setting usedefaultcredentials and credentials as credentialcache.defaultnetworkcredentials to httpwebrequest in c#). If you specify :default-auth it will set these values.
And I found relevant to add a global cookie to use between different request (I had trouble to keep an open connection without it)